### PR TITLE
The change will fix the issue JSON.parse: expected ',' or '}' after p…

### DIFF
--- a/java/page/json/com/acc/aem64/core/servlets/GetPageJsonServlet.java
+++ b/java/page/json/com/acc/aem64/core/servlets/GetPageJsonServlet.java
@@ -79,6 +79,7 @@ public class GetPageJsonServlet extends SlingSafeMethodsServlet {
 			currentResource = getCurrentResource(currentResource);
 			pageTree = new JSONNode(currentResource.getName(), getFilteredValueMap(currentResource.getValueMap()));
 			collectChild(pageTree, currentResource, req, null);
+			resp.setContentType("application/json");
 			resp.getWriter().write(getJsonString(pageTree));
 
 		} catch (Exception e) {


### PR DESCRIPTION
…roperty.

As the value will be sent as JSON, it should be given the content type as application/json. If it is not mentioned it will additionally try to stringify it and leads to the error